### PR TITLE
Add support for hoisted yarn.lock

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
-    if [ -f "${BUILD_DIR}/yarn.lock" ]; then
+    if [ -f "${BUILD_DIR}/yarn.lock" ] && [ ! -f "${ENV_DIR}/${APP_BASE}/yarn.lock" ]; then
         mv "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}/"
     fi
     rm -f "${BUILD_DIR}/${APP_BASE}/lib" &&

--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,7 @@ APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 (
     rm -f "${BUILD_DIR}/${APP_BASE}/lib" &&
     mv "${BUILD_DIR}/lib" "${BUILD_DIR}/${APP_BASE}/lib" &&
+    mv "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}/" &&
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
     rm -rf "${BUILD_DIR}" &&
     mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
-    if [ -f "${BUILD_DIR}/yarn.lock" ] && [ ! -f "${ENV_DIR}/${APP_BASE}/yarn.lock" ]; then
+    if [ -f "${BUILD_DIR}/yarn.lock" ] && [ ! -f "${BUILD_DIR}/${APP_BASE}/yarn.lock" ]; then
         mv "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}/"
     fi
     rm -f "${BUILD_DIR}/${APP_BASE}/lib" &&

--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,6 @@ indent() {
 }
 
 BUILD_DIR="$1"
-CACHE_DIR="$2"
 ENV_DIR="$3"
 STAGE="$(mktemp -d)"
 
@@ -15,9 +14,11 @@ fi
 APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
+    if [ -f "${BUILD_DIR}/yarn.lock" ]; then
+        mv "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}/"
+    fi
     rm -f "${BUILD_DIR}/${APP_BASE}/lib" &&
     mv "${BUILD_DIR}/lib" "${BUILD_DIR}/${APP_BASE}/lib" &&
-    mv "${BUILD_DIR}/yarn.lock" "${BUILD_DIR}/${APP_BASE}/" &&
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
     rm -rf "${BUILD_DIR}" &&
     mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"


### PR DESCRIPTION
@emadel is adding support for [Yarn Workspaces](https://yarnpkg.com/en/docs/workspaces) to the root repo, which results in a hoisted `yarn.lock` file in the base path of the repo as opposed to in each subdirectory.

This patch just checks if that file exists and moves it into the app subdirectory before the rest of the build steps.